### PR TITLE
Fixed a bug where the timestamp was added as script

### DIFF
--- a/lda.py
+++ b/lda.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 from preprocess import clean
 from time import time
@@ -53,7 +52,7 @@ def create_dataset():
 # =============================================================================================
 
 
-def lda(path):
+def lda(data_samples):
 	n_samples = 2000
 	n_features = 1000
 	n_topics = 3
@@ -71,55 +70,55 @@ def lda(path):
 	# footers and quoted replies, and common English words, words occurring in
 	# only one document or in at least 95% of the documents are removed.
 
-	# print("Loading dataset...")
+	# print "Loading dataset..."
 	t0 = time()
 	# dataset = fetch_20newsgroups(shuffle=True, random_state=1, remove=('headers', 'footers', 'quotes'))
 	# data_samples = dataset.data[:n_samples]
 	dataset = create_dataset()
 	# data_samples = dataset
-	with open(path, 'r') as f:
-		data_samples = clean(f.read())
-		data_samples = [x[0] for x in data_samples]
-	# print("done in %0.3fs." % (time() - t0))
-	# print(dataset)
+	# print "done in %0.3fs." % (time() - t0)
+	# print dataset
 
 	# Use tf-idf features for NMF.
-	# print("Extracting tf-idf features for NMF...")
+	# print "Extracting tf-idf features for NMF..."
 	tfidf_vectorizer = TfidfVectorizer(max_df=0.95, min_df=2, max_features=n_features, stop_words='english')
 	t0 = time()
 	tfidf = tfidf_vectorizer.fit_transform(data_samples)
-	# print("done in %0.3fs." % (time() - t0))
+	# print "done in %0.3fs." % (time() - t0)
 
 	# Use tf (raw term count) features for LDA.
-	# print("Extracting tf features for LDA...")
+	# print "Extracting tf features for LDA..."
 	tf_vectorizer = CountVectorizer(max_df=0.95, min_df=2, max_features=n_features, stop_words='english')
 	t0 = time()
 	tf = tf_vectorizer.fit_transform(data_samples)
-	# print("done in %0.3fs." % (time() - t0))
+	# print "done in %0.3fs." % (time() - t0)
 
 	'''
 	# Fit the NMF model
-	print("Fitting the NMF model with tf-idf features, n_samples=%d and n_features=%d..." % (n_samples, n_features))
+	print "Fitting the NMF model with tf-idf features, n_samples=%d and n_features=%d..." % (n_samples, n_features)
 	t0 = time()
 	nmf = NMF(n_components=n_topics, random_state=1, alpha=.1, l1_ratio=.5).fit(tfidf)
-	print("done in %0.3fs." % (time() - t0))
+	print "done in %0.3fs." % (time() - t0)
 
-	print("\nTopics in NMF model:")
+	print "\nTopics in NMF model:"
 	tfidf_feature_names = tfidf_vectorizer.get_feature_names()
-	print(get_top_words(nmf, tfidf_feature_names, n_top_words))
-	print()
+	print get_top_words(nmf, tfidf_feature_names, n_top_words)
+	print 
 	'''
 
-	# print("Fitting LDA models with tf features, n_samples=%d and n_features=%d..." % (n_samples, n_features))
+	# print "Fitting LDA models with tf features, n_samples=%d and n_features=%d..." % (n_samples, n_features)
 	lda = LatentDirichletAllocation(n_topics=n_topics, max_iter=5, learning_method='online', learning_offset=50., random_state=0)
 	t0 = time()
 	lda.fit(tf)
-	# print("done in %0.3fs." % (time() - t0))
+	# print "done in %0.3fs." % (time() - t0)
 
-	# print("\nTopics in LDA model:")
+	# print "\nTopics in LDA model:"
 	tf_feature_names = tf_vectorizer.get_feature_names()
 	return get_top_words(lda, tf_feature_names, n_top_words)
 
 if __name__ == '__main__':
 	path = 'scripts/Advance C/Command-line-arguments-in-C.txt'
-	print(lda(path))
+	with open(path, 'r') as f:
+		data_samples = clean(f.read())
+		data_samples = [x[0] for x in data_samples]
+	print lda(data_samples)

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import re
 from nltk.corpus import stopwords
@@ -11,6 +10,7 @@ def clean(text):
 	text = text.lower()
 	text = re.sub('[#.,$%|~\-/&\"\'`*+=!?;()^]', '', text)
 	text = re.sub('\n ', '\n', text)
+	text = re.sub('\n\n+', '\n\n', text)
 	text = re.sub(' +', ' ', text)
 
 	lines = text.split('\n\n')
@@ -33,7 +33,7 @@ def clean(text):
 	return cleaned_lines
 
 
-def main():
+def clean_all_scripts():
 	clean_dir = 'scripts/clean/'
 	if not os.path.exists(clean_dir):
 		os.mkdir(clean_dir)
@@ -44,7 +44,7 @@ def main():
 		if 'clean' not in root.split(os.sep):
 			for file in files:
 				file_path = os.path.join(root, file)
-				print('Cleaning:', file_path.split(os.sep, maxsplit=2)[-1])
+				print 'Cleaning:', file_path.split(os.sep, maxsplit=2)[-1]
 				f = open(file_path, encoding='utf8')
 				text = f.read()
 				f.close()
@@ -60,7 +60,6 @@ def main():
 
 
 if __name__ == '__main__':
-	# main()
+	# clean_all_scripts()
 	with open('scripts/BASH/Introduction-to-BASH-Shell-Scripting.txt', 'r') as f:
-		file_text = f.read()
-	clean(file_text)
+		print clean(f.read())

--- a/window.py
+++ b/window.py
@@ -1,0 +1,35 @@
+from preprocess import clean
+from datetime import datetime
+
+# window of 60 seconds
+interval = 60
+
+
+def calculate_interval(path):
+	with open(path, 'r') as f:
+		text = clean(f.read())
+	script = [x[0] for x in text]
+	times = [x[1] for x in text]
+
+	time_interval_index = []
+	l = len(times)
+	fmt = '%M:%S'
+	for i in xrange(l):
+		for j in xrange(i+1, l):
+			t1, t2 = times[i], times[j]
+			tdelta = datetime.strptime(t2, fmt) - datetime.strptime(t1, fmt)
+			if tdelta.total_seconds() >= 60:
+				time_interval_index.append(j)
+				break
+		else:
+			time_interval_index.append(l-1)
+	return script, time_interval_index
+
+if __name__ == '__main__':
+	path = 'scripts/Advance C/Command-line-arguments-in-C.txt'
+	script, time_intervals = calculate_interval(path)
+	snippets = []
+	for t in xrange(len(time_intervals)):
+		snippet = ' '.join(script[t:time_intervals[t]])
+		snippets.append(snippet)
+	print snippets[0]


### PR DESCRIPTION
- If there are consecutive multiple empty lines in the transcript, the `clean()` was returning timestamp as a script and the timestamp as an empty string
- Added `window.py` to retrieve script snippets for the given window
- Removed `__future__` imports, now the codes only work with `python2`